### PR TITLE
Add logging functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+bin/
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/kvstore/main.go
+++ b/cmd/kvstore/main.go
@@ -22,7 +22,8 @@ var (
 )
 
 func main() {
-	logger = logging.NewLogger(0, 0, 0, 0, 0, true)
+	logger = logging.DefaultLogger()
+	logger.ConfigureLogger(0, 0, 0, 0, 0, true)
 	logger.Info.Println("KV-Store 0.01")
 	logger.Info.Print("Starting in shell mode\n\n\n")
 	ks = keystore.NewKeyStore()

--- a/cmd/kvstore/main.go
+++ b/cmd/kvstore/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/devguyio/kvstore/internal/tui"
 	"os"
 	"strings"
 
 	"github.com/devguyio/kvstore/internal/keystore"
+	"github.com/devguyio/kvstore/internal/logging"
+	"github.com/devguyio/kvstore/internal/tui"
 )
 
 const (
@@ -16,16 +17,18 @@ const (
 )
 
 var (
-	ks *keystore.KeyStore
+	ks     *keystore.KeyStore
+	logger *logging.Logger
 )
 
 func main() {
-	fmt.Println("KV-Store 0.01")
-	fmt.Print("Starting in shell mode\n\n\n")
+	logger = logging.NewLogger(0, 0, 0, 0, 0, true)
+	logger.Info.Println("KV-Store 0.01")
+	logger.Info.Print("Starting in shell mode\n\n\n")
 	ks = keystore.NewKeyStore()
 	reader := bufio.NewReader(os.Stdin)
 	m := tui.NewMenu(os.Stdin, os.Stdout)
-	m.Add("add_key", "Add/Set Key", "1", func(){
+	m.Add("add_key", "Add/Set Key", "1", func() {
 		fmt.Print("Enter key: ")
 		key, _ := reader.ReadString('\n')
 		key = strings.Replace(key, "\n", "", -1)
@@ -45,7 +48,7 @@ func main() {
 			fmt.Printf("-> Found 1 entry\n\tK: %s -> V: %s\n", key, value)
 		}
 	})
-	m.Add("quit", "Quit", "q", func(){
+	m.Add("quit", "Quit", "q", func() {
 		os.Exit(0)
 	})
 	m.Run()

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/devguyio/kvstore
+
+go 1.14

--- a/internal/keystore/keystore.go
+++ b/internal/keystore/keystore.go
@@ -1,6 +1,10 @@
 package keystore
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/devguyio/kvstore/internal/logging"
+)
 
 // KeyStore is a struct representing an in-memory key-value store
 type KeyStore struct {
@@ -30,6 +34,7 @@ func (ks *KeyStore) Del(k string) error {
 	if _, ok := ks.data[k]; !ok {
 		return errors.New("Invalid key")
 	}
+	logging.DefaultLogger().Debug.Printf("deleting key %s with value %s", k, ks.data[k])
 	delete(ks.data, k)
 	return nil
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -4,12 +4,17 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"sync"
 )
 
 // Logger a collection of `*log.Logger` with different levels.
 type Logger struct {
+	sync.Mutex
 	Info, Warning, Err, Debug, Trace *log.Logger
 }
+
+var defaultLogger *Logger
+var once sync.Once
 
 // NewLogger a factory for Logger struct.
 func NewLogger(tf, ef, wf, nf, df int, debug bool) *Logger {
@@ -28,5 +33,33 @@ func NewLogger(tf, ef, wf, nf, df int, debug bool) *Logger {
 		Warning: log.New(ioutil.Discard, "WARNING: ", wf),
 		Trace:   log.New(ioutil.Discard, "TRACE: ", tf),
 		Debug:   log.New(ioutil.Discard, "DEBUG: ", df),
+	}
+}
+
+// DefaultLogger returns a singleton logger to be used across the app
+func DefaultLogger() *Logger {
+	once.Do(func() {
+		defaultLogger = NewLogger(0, 0, 0, 0, 0, false)
+	})
+	return defaultLogger
+}
+
+// ConfigureLogger set the flags and ouptut stream of the logger.
+func (l *Logger) ConfigureLogger(tf, ef, wf, nf, df int, debug bool) {
+	l.Lock()
+	defer l.Unlock()
+	l.Info.SetFlags(nf)
+	l.Err.SetFlags(ef)
+	l.Warning.SetFlags(wf)
+	l.Trace.SetFlags(tf)
+	l.Debug.SetFlags(df)
+	if debug {
+		l.Warning.SetOutput(os.Stderr)
+		l.Trace.SetOutput(os.Stderr)
+		l.Debug.SetOutput(os.Stderr)
+	} else {
+		l.Warning.SetOutput(ioutil.Discard)
+		l.Trace.SetOutput(ioutil.Discard)
+		l.Debug.SetOutput(ioutil.Discard)
 	}
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,32 @@
+package logging
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+// Logger a collection of `*log.Logger` with different levels.
+type Logger struct {
+	Info, Warning, Err, Debug, Trace *log.Logger
+}
+
+// NewLogger a factory for Logger struct.
+func NewLogger(tf, ef, wf, nf, df int, debug bool) *Logger {
+	if debug {
+		return &Logger{
+			Info:    log.New(os.Stdout, "INFO: ", nf),
+			Err:     log.New(os.Stderr, "ERROR: ", ef),
+			Warning: log.New(os.Stderr, "WARNING: ", wf),
+			Trace:   log.New(os.Stderr, "TRACE: ", tf),
+			Debug:   log.New(os.Stderr, "DEBUG: ", df),
+		}
+	}
+	return &Logger{
+		Info:    log.New(os.Stdout, "INFO: ", nf),
+		Err:     log.New(os.Stderr, "ERROR: ", ef),
+		Warning: log.New(ioutil.Discard, "WARNING: ", wf),
+		Trace:   log.New(ioutil.Discard, "TRACE: ", tf),
+		Debug:   log.New(ioutil.Discard, "DEBUG: ", df),
+	}
+}


### PR DESCRIPTION
solving issue #12 
- [x] There's by default support for five loggers, info, warning, error, debug and trace.
- [x] info and error are configured by default to log to stdout & stderr
- [x] warning, debug and trace by default log to `ioutil.Discard`
- [x] during the program init, one can enable warning, debug and trace, in which case they will all log to stderr by default for now
- [x] it's possible to configure log flags per logger type.

questions:
- I see that the whole app is running in a single goroutine so far, but is it a good idea to build a singleton logger (python style) to be used through the app, otherwise, the logger will need to be passed from main to all goroutines
- I hate to test the obvious like boilerplate code or stuff provided by the std library, what kind of tests are needed here
- how to get the log configurations from the user, cmd options, config file, ... etc
- log formatting?